### PR TITLE
Change virtual queue implementation to create virtual queue direct

### DIFF
--- a/src/main/java/com/amazonaws/services/sqs/ISQSMessageHandler.java
+++ b/src/main/java/com/amazonaws/services/sqs/ISQSMessageHandler.java
@@ -1,0 +1,16 @@
+package com.amazonaws.services.sqs;
+
+import com.amazonaws.services.sqs.model.Message;
+
+/**
+ * The Interface ISQSMessageHandler.
+ */
+public interface ISQSMessageHandler {
+	
+	/**
+	 * Handle message.
+	 *
+	 * @param msg the msg
+	 */
+	public void handleMessage(Message msg);
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1.    Make AmazonSQSVirtualQueuesClient public.
2.    Overload createQueue method.
3.    Provide handler to dispatch messages directly.
4.    Remove SQS delete queue from SQS cloud.
5.    Make Host Queue polling time and Concurrency configurable.
6.    Change MAX virtual queue number from 10_000 to 10_000_00.
7.    Add ISQSMessageHandler interface.
8.    Modify SQSMessageConsumer to make concurrency and polling time configurable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

