### PR TITLE
Changed queue url attribute name to be configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-temporary-queues-client</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.1.NEOFECT</version>
   <name>Amazon SQS Java Temporary Queues Client</name>
   <description>An Amazon SQS client that supports creating lightweight, automatically-deleted temporary queues, for use in common messaging patterns such as Request/Response. See http://aws.amazon.com/sqs.</description>
   <url>https://github.com/awslabs/amazon-sqs-java-temporary-queues-client</url>

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -6,10 +6,11 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AmazonSQSRequesterClientBuilder {
-    
     private Optional<AmazonSQS> customSQS = Optional.empty();
     
     private String internalQueuePrefix = "__RequesterClientQueues__";
+
+    private String internalQueueUrlAttribute = "ResponseQueueUrl";
     
     private Map<String, String> queueAttributes = Collections.emptyMap();
     
@@ -43,7 +44,15 @@ public class AmazonSQSRequesterClientBuilder {
     public String getInternalQueuePrefix() {
         return internalQueuePrefix;
     }
+
+    public String getInternalQueueUrlAttribute() {
+        return internalQueueUrlAttribute;
+    }
     
+    public void setInternalQueueUrlAttribute(String internalQueueUrlAttribute) {
+        this.internalQueueUrlAttribute = internalQueueUrlAttribute;
+    }
+
     public void setInternalQueuePrefix(String internalQueuePrefix) {
         this.internalQueuePrefix = internalQueuePrefix;
     }
@@ -52,7 +61,12 @@ public class AmazonSQSRequesterClientBuilder {
         setInternalQueuePrefix(internalQueuePrefix);
         return this;
     }
-    
+
+    public AmazonSQSRequesterClientBuilder withInternalQueueUrlAttribute(String internalQueueUrlAttribute) {
+        setInternalQueueUrlAttribute(internalQueueUrlAttribute);
+        return this;
+    }
+
     public Map<String, String> getQueueAttributes() {
         return Collections.unmodifiableMap(queueAttributes);
     }
@@ -69,7 +83,7 @@ public class AmazonSQSRequesterClientBuilder {
     public AmazonSQSRequester build() {
         AmazonSQS sqs = customSQS.orElseGet(AmazonSQSClientBuilder::defaultClient);
         AmazonSQSTemporaryQueuesClient temporaryQueuesClient = AmazonSQSTemporaryQueuesClient.makeWrappedClient(sqs, internalQueuePrefix);
-        AmazonSQSRequesterClient requester = new AmazonSQSRequesterClient(temporaryQueuesClient, internalQueuePrefix, queueAttributes);
+        AmazonSQSRequesterClient requester = new AmazonSQSRequesterClient(temporaryQueuesClient, internalQueuePrefix, internalQueueUrlAttribute, queueAttributes);
         AmazonSQSResponderClient responder = new AmazonSQSResponderClient(sqs);
         temporaryQueuesClient.startIdleQueueSweeper(requester, responder);
         if (customSQS.isPresent()) {


### PR DESCRIPTION
AmazonSQSClientBuilder

*Description of changes:*
We have legacy system which is using queue url attribute for response like this library but different name.
To use this library for our legacy system.  queue url attribute has to be configurable like following code

`
AmazonSQSRequesterClientBuilder.standard()
                .withAmazonSQS(sqs)
                .withInternalQueueUrlAttribute("blablabla")
                .build()
`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
