### PR TITLE
Whitelisting most queue attributes for temporary queues

### DIFF
--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
@@ -1,0 +1,69 @@
+package com.amazonaws.services.sqs;
+
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.QueueAttributeName;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.util.IntegrationTest;
+import com.amazonaws.services.sqs.util.SQSMessageConsumer;
+import com.amazonaws.services.sqs.util.SQSMessageConsumerBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class AmazonSQSResponsesClientCrossAccountIT extends IntegrationTest {
+    private static AmazonSQSRequester sqsRequester;
+    private static AmazonSQSResponder sqsResponder;
+    private static String requestQueueUrl;
+
+    @Override
+    protected String testSuiteName() {
+        return "SQSXAccountResponsesClientIT";
+    }
+
+    @Before
+    public void setup() {
+        String policyString = allowSendMessagePolicy().toJson();
+        sqsRequester = new AmazonSQSRequesterClient(sqs, queueNamePrefix,
+                Collections.singletonMap(QueueAttributeName.Policy.toString(), policyString),
+                exceptionHandler);
+        // Use the second account for the responder
+        sqsResponder = new AmazonSQSResponderClient(getBuddyPrincipalClient());
+        requestQueueUrl = sqs.createQueue("RequestQueue-" + UUID.randomUUID().toString()).getQueueUrl();
+    }
+
+    @After
+    public void teardown() {
+        sqs.deleteQueue(requestQueueUrl);
+        sqsResponder.shutdown();
+        sqsRequester.shutdown();
+    }
+
+    @Test
+    public void test() throws Exception {
+        SQSMessageConsumer consumer = SQSMessageConsumerBuilder.standard()
+                .withAmazonSQS(sqs)
+                .withQueueUrl(requestQueueUrl)
+                .withConsumer(message -> {
+                    sqsResponder.sendResponseMessage(MessageContent.fromMessage(message),
+                            new MessageContent("Right back atcha buddy!"));
+                })
+                .build();
+        consumer.start();
+        try {
+            SendMessageRequest request = new SendMessageRequest()
+                    .withMessageBody("Hi there!")
+                    .withQueueUrl(requestQueueUrl);
+            Message replyMessage = sqsRequester.sendMessageAndGetResponse(request, 5, TimeUnit.SECONDS);
+    
+            assertEquals("Right back atcha buddy!", replyMessage.getBody());
+        } finally {
+            consumer.terminate();
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientCrossAccountIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientCrossAccountIT.java
@@ -1,0 +1,102 @@
+package com.amazonaws.services.sqs;
+
+import com.amazonaws.services.sqs.model.AmazonSQSException;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.QueueAttributeName;
+import com.amazonaws.services.sqs.util.AbstractAmazonSQSClientWrapper;
+import com.amazonaws.services.sqs.util.IntegrationTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class AmazonSQSTemporaryQueuesClientCrossAccountIT extends IntegrationTest {
+
+    @Parameters(name= "With temporary queues = {0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] { { false }, { true } } );
+    }
+
+    // Parameterized to emphasize that the same client code for physical SQS queues
+    // should work for temporary queues as well, even thought they are virtual.
+    private final boolean withTemporaryQueues;
+    private AmazonSQS client;
+    private AmazonSQS otherAccountClient;
+
+    public AmazonSQSTemporaryQueuesClientCrossAccountIT(boolean withTemporaryQueues) {
+        this.withTemporaryQueues = withTemporaryQueues;
+    }
+
+    @Before
+    public void setup() {
+        client = makeTemporaryQueueClient(sqs);
+        otherAccountClient = makeTemporaryQueueClient(getBuddyPrincipalClient());
+    }
+
+    @After
+    public void teardown() {
+        client.shutdown();
+    }
+
+    private AmazonSQS makeTemporaryQueueClient(AmazonSQS sqs) {
+        if (withTemporaryQueues) {
+            AmazonSQSRequesterClientBuilder requesterBuilder =
+                    AmazonSQSRequesterClientBuilder.standard()
+                            .withAmazonSQS(sqs)
+                            .withInternalQueuePrefix(queueNamePrefix)
+                            .withIdleQueueSweepingPeriod(0, TimeUnit.SECONDS);
+            return AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
+        } else {
+            // Use a wrapper just to avoid shutting down the client from
+            // the base class too early.
+            return new AbstractAmazonSQSClientWrapper(sqs);
+        }
+    }
+
+    @Override
+    protected String testSuiteName() {
+        return "SQSXAccountTempQueueIT";
+    }
+
+    @Test
+    public void accessDenied() {
+        // Assert that a different principal is not permitted to
+        // send to virtual queues
+        String virtualQueueUrl = client.createQueue(queueNamePrefix + "TestQueueWithoutAccess").getQueueUrl();
+        try {
+            otherAccountClient.sendMessage(virtualQueueUrl, "Haxxors!!");
+            Assert.fail("Should not have been able to send a message");
+        } catch (AmazonSQSException e) {
+            // Access Denied
+            assertEquals(403, e.getStatusCode());
+        } finally {
+            client.deleteQueue(virtualQueueUrl);
+        }
+    }
+
+    @Test
+    public void withAccess() {
+        String policyString = allowSendMessagePolicy().toJson();
+        CreateQueueRequest createQueueRequest = new CreateQueueRequest()
+                .withQueueName(queueNamePrefix + "TestQueueWithAccess")
+                .withAttributes(Collections.singletonMap(QueueAttributeName.Policy.toString(), policyString));
+
+        String queueUrl = client.createQueue(createQueueRequest).getQueueUrl();
+        try {
+            otherAccountClient.sendMessage(queueUrl, "Hi there!");
+        } finally {
+            client.deleteQueue(queueUrl);
+        }
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.QueueAttributeName;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,13 +33,15 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
     
     @After
     public void teardown() {
-        client.deleteQueue(queueUrl);
+        if (queueUrl != null) {
+            client.deleteQueue(queueUrl);
+        }
         client.shutdown();
     }
     
     @Test
     public void createQueueAddsAttributes() {
-        queueUrl = client.createQueue("TestQueue").getQueueUrl();
+        queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
         Map<String, String> attributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
         String hostQueueUrl = attributes.get(VIRTUAL_QUEUE_HOST_QUEUE_ATTRIBUTE);
         assertNotNull(hostQueueUrl);
@@ -45,5 +49,17 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
         
         Map<String, String> hostQueueAttributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
         Assert.assertEquals("300", hostQueueAttributes.get(AmazonSQSIdleQueueDeletingClient.IDLE_QUEUE_RETENTION_PERIOD));
+    }
+
+    @Test
+    public void createQueueWithUnsupportedAttributes() {
+        try {
+            client.createQueue(new CreateQueueRequest()
+                    .withQueueName(queueNamePrefix + "InvalidQueue")
+                    .withAttributes(Collections.singletonMap(QueueAttributeName.FifoQueue.name(), "true")));
+            Assert.fail("Shouldn't be able to create a FIFO temporary queue");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Cannot create a temporary queue with the following attributes: FifoQueue", e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/amazonaws/services/sqs/util/IntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/sqs/util/IntegrationTest.java
@@ -1,13 +1,27 @@
 package com.amazonaws.services.sqs.util;
 
+import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.SQSActions;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.sqs.model.AmazonSQSException;
 import org.junit.After;
 import org.junit.Before;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assume.assumeNoException;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Base class for integration tests
@@ -16,9 +30,16 @@ public abstract class IntegrationTest {
     
     protected AmazonSQS sqs;
     // UUIDs are too long for this
-    protected String queueNamePrefix = "__" + getClass().getSimpleName() + "-" + ThreadLocalRandom.current().nextInt(1000000);
+    protected String queueNamePrefix = "__" + testSuiteName() + "-" + ThreadLocalRandom.current().nextInt(1000000);
     protected ExceptionAsserter exceptionHandler = new ExceptionAsserter();
-    
+
+    /**
+     * Customizable to ensure queue names stay under 80 characters
+     */
+    protected String testSuiteName() {
+        return getClass().getSimpleName();
+    }
+
     @Before
     public void setupSQSClient() {
         sqs = AmazonSQSClientBuilder.defaultClient();
@@ -39,5 +60,45 @@ public abstract class IntegrationTest {
             sqs.shutdown();
         }
         exceptionHandler.assertNothingThrown();
+    }
+
+    protected AmazonSQS getBuddyPrincipalClient() {
+        AWSCredentialsProvider credentialsProvider = new ProfileCredentialsProvider("buddy");
+        try {
+            credentialsProvider.getCredentials();
+        } catch (Exception e) {
+            assumeNoException("This test requires a second 'buddy' credential profile.", e);
+        }
+
+        AmazonSQS client = AmazonSQSClientBuilder.standard()
+                .withRegion("us-west-2")
+                .withCredentials(credentialsProvider)
+                .build();
+
+        // Assume that the principal is not able to send messages to arbitrary queues
+        String queueUrl = sqs.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
+        try {
+            client.sendMessage(queueUrl, "Haxxors!!");
+            assumeTrue("The buddy credentials should not authorize sending to arbitrary queues", false);
+        } catch (AmazonSQSException e) {
+            // Access Denied
+            assumeThat(e.getStatusCode(), equalTo(403));
+        } finally {
+            sqs.deleteQueue(queueUrl);
+        }
+
+        return client;
+    }
+
+    protected Policy allowSendMessagePolicy() {
+        Policy policy = new Policy();
+        Statement statement = new Statement(Statement.Effect.Allow);
+        statement.setActions(Collections.singletonList(SQSActions.SendMessage));
+        // Ideally we would only allow the principal we're testing with, but we
+        // only have access to the credentials and not necessarily the account number.
+        statement.setPrincipals(Principal.All);
+        statement.setResources(Collections.singletonList(new Resource("arn:aws:sqs:*:*:*")));
+        policy.setStatements(Collections.singletonList(statement));
+        return policy;
     }
 }


### PR DESCRIPTION
In particular, this makes cross-account use cases work because you
can attach Policies to individual response queues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
