### PR TITLE
Adding @PreDestroy annotation to public facing shutdown methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target/
+.idea
+.classpath
+.project
+*.iml

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequester.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequester.java
@@ -1,12 +1,13 @@
 package com.amazonaws.services.sqs;
 
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+
+import javax.annotation.PreDestroy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
 
 public interface AmazonSQSRequester {
 
@@ -26,5 +27,6 @@ public interface AmazonSQSRequester {
     public CompletableFuture<Message> sendMessageAndGetResponseAsync(SendMessageRequest request, 
             int timeout, TimeUnit unit);
 
+    @PreDestroy
     public void shutdown();
 }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClient.java
@@ -18,6 +18,8 @@ import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.util.SQSMessageConsumer;
 import com.amazonaws.services.sqs.util.SQSQueueUtils;
 
+import javax.annotation.PreDestroy;
+
 /**
  * Implementation of the request/response interfaces that creates a single
  * temporary queue for each response message.
@@ -76,7 +78,7 @@ class AmazonSQSRequesterClient implements AmazonSQSRequester {
         sqs.sendMessage(requestWithResponseUrl);
 
         CompletableFuture<Message> future = new CompletableFuture<>();
-        
+
         // TODO-RS: accept an AmazonSQSAsync instead and use its threads instead of our own.
         // TODO-RS: complete the future exceptionally, for the right set of SQS exceptions
         SQSMessageConsumer consumer = new ResponseListener(responseQueueUrl, future);
@@ -110,6 +112,7 @@ class AmazonSQSRequesterClient implements AmazonSQSRequester {
     }
     
     @Override
+    @PreDestroy
     public void shutdown() {
         responseConsumers.forEach(SQSMessageConsumer::terminate);
         if (shutdownHook != null) {

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponder.java
@@ -1,6 +1,6 @@
 package com.amazonaws.services.sqs;
 
-import com.amazonaws.services.sqs.AmazonSQS;
+import javax.annotation.PreDestroy;
 
 public interface AmazonSQSResponder {
     
@@ -21,5 +21,6 @@ public interface AmazonSQSResponder {
      */
     public void sendResponseMessage(MessageContent requestMessage, MessageContent response);
 
+    @PreDestroy
     public void shutdown();
 }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponderClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponderClient.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 
+import javax.annotation.PreDestroy;
+
 class AmazonSQSResponderClient implements AmazonSQSResponder {
     
     private static final Log LOG = LogFactory.getLog(AmazonSQSResponderClient.class);
@@ -49,6 +51,7 @@ class AmazonSQSResponderClient implements AmazonSQSResponder {
     }
     
     @Override
+    @PreDestroy
     public void shutdown() {
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Pretty simple change, but not necessarily desired. This won't impact simple (unframeworked) codebases like the [example](https://github.com/aws-samples/amazon-sqs-java-temporary-queues-client-samples), but could be a nice addition to people using frameworks to manage object states.

I did not add the annotation to `SQSMessageConsumer` as it already implements AutoCloseable, and its `close` method already calls `shutdowon()`. Furthermore, the `SQSMessageConsumer`'s `shutdown()` method is already called by `AmazonSQSRequesterClient`'s `shutdown()`.

A potential downsides is reducing user control if they want to shutdown either client in a non-graceful way, but I think that is outweighed by the benefit.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
