### PR TITLE
Auto-boxing null Integer to long causing NPE

### DIFF
--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
@@ -349,7 +349,7 @@ class AmazonSQSVirtualQueuesClient extends AbstractAmazonSQSClientWrapper {
             try {
                 try {
                     return receiveBuffer.receiveMessageAsync(request)
-                                        .get(request.getWaitTimeSeconds(), TimeUnit.SECONDS);
+                                        .get(Optional.ofNullable(request.getWaitTimeSeconds()).orElse(0).longValue(), TimeUnit.SECONDS);
                 } catch (TimeoutException e) {
                     // Fall through to an empty receive
                 } catch (ExecutionException e) {

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientIT.java
@@ -63,4 +63,22 @@ public class AmazonSQSVirtualQueuesClientIT extends IntegrationTest {
             // Expected
         }
     }
+
+    @Test
+    public void ReceiveMessageWaitTimeSecondsNull() {
+        CreateQueueRequest request = new CreateQueueRequest()
+                .withQueueName("ReceiveMessageWaitTimeSecondsNull")
+                .addAttributesEntry(AmazonSQSVirtualQueuesClient.VIRTUAL_QUEUE_HOST_QUEUE_ATTRIBUTE, hostQueueUrl)
+                .addAttributesEntry(AmazonSQSIdleQueueDeletingClient.IDLE_QUEUE_RETENTION_PERIOD, "5");
+        String virtualQueueUrl = client.createQueue(request).getQueueUrl();
+
+        // Do Receive message request with null WaitTimeSeconds.
+        ReceiveMessageRequest receiveRequest = new ReceiveMessageRequest()
+                .withQueueUrl(virtualQueueUrl);
+        try {
+            assertEquals(0, client.receiveMessage(receiveRequest).getMessages().size());
+        } catch (NullPointerException npe) {
+            fail("NPE not expected with null WaitTimeSeconds on ReceiveMessageRequest");
+        }
+    }
 }


### PR DESCRIPTION
*Issue #4, NPE when short-polling a virtual queue* 

*Description of changes:*
Appears that the ReceiveMessageRequest.waitTimeSeconds is type Integer, so it will be null if not provided. The Completable future get timeout seconds is long type. So the NPE is a result of the auto-boxing of Integer to long which isn't clear as it's happening under the hood in the JVM.

Added check for null and removed implicit auto-boxing by calling longValue() method on Integer object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
