### PR TITLE
fix: Typos in SQSScheduledExecutorService delay math

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
       <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/amazonaws/services/sqs/SQSScheduledExecutorService.java
+++ b/src/main/java/com/amazonaws/services/sqs/SQSScheduledExecutorService.java
@@ -122,10 +122,7 @@ public class SQSScheduledExecutorService extends SQSExecutorService implements S
         public SendMessageRequest toSendMessageRequest() {
             SendMessageRequest request = super.toSendMessageRequest();
 
-            int sqsDelaySeconds = (int)Math.min(TimeUnit.NANOSECONDS.toSeconds(Math.abs(delay)), MAX_SQS_DELAY_SECONDS);
-            if (sqsDelaySeconds <= 0) {
-                sqsDelaySeconds = 1;
-            }
+            int sqsDelaySeconds = Math.max(1, (int)Math.min(TimeUnit.NANOSECONDS.toSeconds(delay), MAX_SQS_DELAY_SECONDS));
             request.setDelaySeconds(sqsDelaySeconds);
 
             return request;

--- a/src/main/java/com/amazonaws/services/sqs/SQSScheduledExecutorService.java
+++ b/src/main/java/com/amazonaws/services/sqs/SQSScheduledExecutorService.java
@@ -62,11 +62,11 @@ public class SQSScheduledExecutorService extends SQSExecutorService implements S
             this.period = unit.toNanos(period);
 
             messageContent.setMessageAttributesEntry(DELAY_NANOS_ATTRIBUTE_NAME, 
-                    longMessageAttributeValue(delay));
+                    longMessageAttributeValue(this.delay));
             messageContent.setMessageAttributesEntry(PERIOD_NANOS_ATTRIBUTE_NAME, 
-                    longMessageAttributeValue(period));
+                    longMessageAttributeValue(this.period));
 
-            this.time = getTime(delay);
+            this.time = getTime(this.delay);
         }
 
         public ScheduledSQSFutureTask(Message message) {
@@ -122,8 +122,8 @@ public class SQSScheduledExecutorService extends SQSExecutorService implements S
         public SendMessageRequest toSendMessageRequest() {
             SendMessageRequest request = super.toSendMessageRequest();
 
-            int sqsDelaySeconds = (int)Math.min(TimeUnit.NANOSECONDS.toSeconds(delay), MAX_SQS_DELAY_SECONDS);
-            if (sqsDelaySeconds < 0) {
+            int sqsDelaySeconds = (int)Math.min(TimeUnit.NANOSECONDS.toSeconds(Math.abs(delay)), MAX_SQS_DELAY_SECONDS);
+            if (sqsDelaySeconds <= 0) {
                 sqsDelaySeconds = 1;
             }
             request.setDelaySeconds(sqsDelaySeconds);

--- a/src/test/java/com/amazonaws/services/sqs/IdleQueueSweeperIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/IdleQueueSweeperIT.java
@@ -22,7 +22,7 @@ public class IdleQueueSweeperIT extends IntegrationTest {
 
     @Before
     public void setup() {
-        requester = AmazonSQSRequesterClientBuilder.standard().withAmazonSQS(sqs).build();
+        requester = AmazonSQSRequesterClientBuilder.standard().withAmazonSQS(sqs).withIdleQueueSweepingPeriod(0, TimeUnit.SECONDS).build();
         responder = AmazonSQSResponderClientBuilder.standard().withAmazonSQS(sqs).build();
         sweepingQueueUrl = sqs.createQueue(queueNamePrefix).getQueueUrl();
         sweeper = new IdleQueueSweeper(requester, responder, sweepingQueueUrl, queueNamePrefix, 5, TimeUnit.SECONDS, exceptionHandler);


### PR DESCRIPTION
*Issue #, if available:*

- #28

*Description of changes:*

Also improved test coverage for this area via Awaitility, specifically setting a minimum wait time for tasks to execute, since the effect of this bug was to trigger recurring tasks too early.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
