### PR TITLE
Use a secondary role to test cross-account functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <version>4.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
@@ -28,7 +28,7 @@ public class AmazonSQSResponsesClientCrossAccountIT extends IntegrationTest {
 
     @Before
     public void setup() {
-        // Use the second account for the responder
+        // Use the secondary role for the responder
         sqsResponder = new AmazonSQSResponderClient(getBuddyPrincipalClient());
 
         String policyString = allowSendMessagePolicy(getBuddyRoleARN()).toJson();

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSResponsesClientCrossAccountIT.java
@@ -28,12 +28,14 @@ public class AmazonSQSResponsesClientCrossAccountIT extends IntegrationTest {
 
     @Before
     public void setup() {
-        String policyString = allowSendMessagePolicy().toJson();
+        // Use the second account for the responder
+        sqsResponder = new AmazonSQSResponderClient(getBuddyPrincipalClient());
+
+        String policyString = allowSendMessagePolicy(getBuddyRoleARN()).toJson();
         sqsRequester = new AmazonSQSRequesterClient(sqs, queueNamePrefix,
                 Collections.singletonMap(QueueAttributeName.Policy.toString(), policyString),
                 exceptionHandler);
-        // Use the second account for the responder
-        sqsResponder = new AmazonSQSResponderClient(getBuddyPrincipalClient());
+
         requestQueueUrl = sqs.createQueue("RequestQueue-" + UUID.randomUUID().toString()).getQueueUrl();
     }
 

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientCrossAccountIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientCrossAccountIT.java
@@ -86,7 +86,7 @@ public class AmazonSQSTemporaryQueuesClientCrossAccountIT extends IntegrationTes
 
     @Test
     public void withAccess() {
-        String policyString = allowSendMessagePolicy().toJson();
+        String policyString = allowSendMessagePolicy(getBuddyRoleARN()).toJson();
         CreateQueueRequest createQueueRequest = new CreateQueueRequest()
                 .withQueueName(queueNamePrefix + "TestQueueWithAccess")
                 .withAttributes(Collections.singletonMap(QueueAttributeName.Policy.toString(), policyString));


### PR DESCRIPTION
This supports a less permissive policy on the test queue, and is better than requiring long-lived credentials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
