### PR TITLE
Allow configuration of IdleQueueRetentionPeriodSeconds on temporary queue client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.7.0-M1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.7.0-M1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.10.0</version>

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -17,7 +17,7 @@ public class AmazonSQSRequesterClientBuilder {
     private int idleQueueSweepingPeriod = 5;
     private long queueHeartbeatInterval = AmazonSQSIdleQueueDeletingClient.HEARTBEAT_INTERVAL_SECONDS_DEFAULT;
     private TimeUnit idleQueueSweepingTimeUnit = TimeUnit.MINUTES;
-    private long idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
+    private long idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.IDLE_QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
     
     private AmazonSQSRequesterClientBuilder() {
     }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -17,7 +17,7 @@ public class AmazonSQSRequesterClientBuilder {
     private int idleQueueSweepingPeriod = 5;
     private long queueHeartbeatInterval = AmazonSQSIdleQueueDeletingClient.HEARTBEAT_INTERVAL_SECONDS_DEFAULT;
     private TimeUnit idleQueueSweepingTimeUnit = TimeUnit.MINUTES;
-    private long queueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
+    private long idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
     
     private AmazonSQSRequesterClientBuilder() {
     }
@@ -90,16 +90,16 @@ public class AmazonSQSRequesterClientBuilder {
         return this;
     }
 
-    public long getQueueRetentionPeriodSeconds() {
-        return queueRetentionPeriodSeconds;
+    public long getIdleQueueRetentionPeriodSeconds() {
+        return idleQueueRetentionPeriodSeconds;
     }
 
-    public void setQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
-        this.queueRetentionPeriodSeconds = queueRetentionPeriodSeconds;
+    public void setIdleQueueRetentionPeriodSeconds(long idleQueueRetentionPeriodSeconds) {
+        this.idleQueueRetentionPeriodSeconds = idleQueueRetentionPeriodSeconds;
     }
 
-    public AmazonSQSRequesterClientBuilder withQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
-        setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
+    public AmazonSQSRequesterClientBuilder withIdleQueueRetentionPeriodSeconds(long idleQueueRetentionPeriodSeconds) {
+        setIdleQueueRetentionPeriodSeconds(idleQueueRetentionPeriodSeconds);
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -16,6 +16,7 @@ public class AmazonSQSRequesterClientBuilder {
     
     private int idleQueueSweepingPeriod = 5;
     private TimeUnit idleQueueSweepingTimeUnit = TimeUnit.MINUTES;
+    private String queueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
     
     private AmazonSQSRequesterClientBuilder() {
     }
@@ -87,8 +88,22 @@ public class AmazonSQSRequesterClientBuilder {
         setIdleQueueSweepingPeriod(period, timeUnit);
         return this;
     }
+
+    public String getQueueRetentionPeriodSeconds() {
+        return queueRetentionPeriodSeconds;
+    }
+
+    public void setQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+        this.queueRetentionPeriodSeconds = queueRetentionPeriodSeconds;
+    }
+
+    public AmazonSQSRequesterClientBuilder withQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+        setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
+        return this;
+    }
     
     public AmazonSQSRequester build() {
         return AmazonSQSTemporaryQueuesClient.make(this).getRequester();
     }
+
 }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -16,7 +16,7 @@ public class AmazonSQSRequesterClientBuilder {
     
     private int idleQueueSweepingPeriod = 5;
     private TimeUnit idleQueueSweepingTimeUnit = TimeUnit.MINUTES;
-    private String queueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
+    private long queueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
     
     private AmazonSQSRequesterClientBuilder() {
     }
@@ -89,15 +89,15 @@ public class AmazonSQSRequesterClientBuilder {
         return this;
     }
 
-    public String getQueueRetentionPeriodSeconds() {
+    public long getQueueRetentionPeriodSeconds() {
         return queueRetentionPeriodSeconds;
     }
 
-    public void setQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+    public void setQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
         this.queueRetentionPeriodSeconds = queueRetentionPeriodSeconds;
     }
 
-    public AmazonSQSRequesterClientBuilder withQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+    public AmazonSQSRequesterClientBuilder withQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
         setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
         return this;
     }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
@@ -66,7 +66,7 @@ class AmazonSQSTemporaryQueuesClient extends AbstractAmazonSQSClientWrapper {
             AmazonSQSIdleQueueDeletingClient.checkQueueRetentionPeriodBounds(idleQueueRetentionPeriodSeconds);
             this.idleQueueRetentionPeriodSeconds = idleQueueRetentionPeriodSeconds;
         } else {
-            this.idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
+            this.idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.IDLE_QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
         }
     }
     

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AmazonSQSTemporaryQueuesClientBuilder {
 
-    public final static String QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT = "300";
+    public final static long QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT = 300;
 
     private AmazonSQSRequesterClientBuilder requesterBuilder = AmazonSQSRequesterClientBuilder.standard();
     
@@ -38,15 +38,15 @@ public class AmazonSQSTemporaryQueuesClientBuilder {
         return this;
     }
 
-    public String getQueueRetentionPeriodSeconds() {
+    public long getQueueRetentionPeriodSeconds() {
         return requesterBuilder.getQueueRetentionPeriodSeconds();
     }
 
-    public void setQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+    public void setQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
         requesterBuilder.setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
     }
 
-    public AmazonSQSTemporaryQueuesClientBuilder withQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+    public AmazonSQSTemporaryQueuesClientBuilder withQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
         setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
         return this;
     }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
@@ -38,16 +38,16 @@ public class AmazonSQSTemporaryQueuesClientBuilder {
         return this;
     }
 
-    public long getQueueRetentionPeriodSeconds() {
-        return requesterBuilder.getQueueRetentionPeriodSeconds();
+    public long getIdleQueueRetentionPeriodSeconds() {
+        return requesterBuilder.getIdleQueueRetentionPeriodSeconds();
     }
 
-    public void setQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
-        requesterBuilder.setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
+    public void setIdleQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
+        requesterBuilder.setIdleQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
     }
 
-    public AmazonSQSTemporaryQueuesClientBuilder withQueueRetentionPeriodSeconds(long queueRetentionPeriodSeconds) {
-        setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
+    public AmazonSQSTemporaryQueuesClientBuilder withIdleQueueRetentionPeriodSeconds(long idleQueueRetentionPeriodSeconds) {
+        setIdleQueueRetentionPeriodSeconds(idleQueueRetentionPeriodSeconds);
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AmazonSQSTemporaryQueuesClientBuilder {
 
-    public final static long QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT = 300;
+    public final static long IDLE_QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT = 300;
 
     private AmazonSQSRequesterClientBuilder requesterBuilder = AmazonSQSRequesterClientBuilder.standard();
     

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientBuilder.java
@@ -5,6 +5,8 @@ import java.util.concurrent.TimeUnit;
 
 public class AmazonSQSTemporaryQueuesClientBuilder {
 
+    public final static String QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT = "300";
+
     private AmazonSQSRequesterClientBuilder requesterBuilder = AmazonSQSRequesterClientBuilder.standard();
     
     private AmazonSQSTemporaryQueuesClientBuilder() {
@@ -33,6 +35,19 @@ public class AmazonSQSTemporaryQueuesClientBuilder {
     
     public AmazonSQSTemporaryQueuesClientBuilder withQueuePrefix(String queuePrefix) {
         setQueuePrefix(queuePrefix);
+        return this;
+    }
+
+    public String getQueueRetentionPeriodSeconds() {
+        return requesterBuilder.getQueueRetentionPeriodSeconds();
+    }
+
+    public void setQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+        requesterBuilder.setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
+    }
+
+    public AmazonSQSTemporaryQueuesClientBuilder withQueueRetentionPeriodSeconds(String queueRetentionPeriodSeconds) {
+        setQueueRetentionPeriodSeconds(queueRetentionPeriodSeconds);
         return this;
     }
 

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.amazonaws.services.sqs.util.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
 
 public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
 
@@ -69,7 +70,7 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
                 AmazonSQSRequesterClientBuilder.standard()
                         .withAmazonSQS(sqs)
                         .withInternalQueuePrefix(queueNamePrefix)
-                        .withQueueRetentionPeriodSeconds("200");
+                        .withQueueRetentionPeriodSeconds(200);
         client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
 
         queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
@@ -84,17 +85,13 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
 
     @Test
     public void createQueueWithUnsupportedIdleQueueRetentionPeriod() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             AmazonSQSRequesterClientBuilder requesterBuilder =
                     AmazonSQSRequesterClientBuilder.standard()
                             .withAmazonSQS(sqs)
                             .withInternalQueuePrefix(queueNamePrefix)
-                            .withQueueRetentionPeriodSeconds("500");
+                            .withQueueRetentionPeriodSeconds(500);
             client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
-
-            Assert.fail("Shouldn't be able to create a temporary queue with QueueRetentionPeriodSeconds not between 1 and 300 seconds");
-        } catch (IllegalArgumentException e) {
-            Assert.assertEquals("The IdleQueueRetentionPeriodSeconds attribute must be between 1 and 300 seconds", e.getMessage());
-        }
+        });
     }
 }

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
@@ -33,7 +33,7 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
     
     @Test
     public void createQueueAddsAttributes() {
-        createQueue(null);
+        createQueueShouldSetRetentionPeriod(null);
     }
 
     @Test
@@ -48,7 +48,7 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
 
     @Test
     public void createQueueConfigurableIdleQueueRetentionPeriod() {
-        createQueue(200L);
+        createQueueShouldSetRetentionPeriod(200L);
     }
 
     @Test
@@ -60,23 +60,19 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
 
     private void setupClient(Long idleQueueRetentionPeriod) {
         AmazonSQSRequesterClientBuilder requesterBuilder;
+
+        requesterBuilder =
+                AmazonSQSRequesterClientBuilder.standard()
+                        .withAmazonSQS(sqs)
+                        .withInternalQueuePrefix(queueNamePrefix);
         if (idleQueueRetentionPeriod != null) {
-            requesterBuilder =
-                    AmazonSQSRequesterClientBuilder.standard()
-                            .withAmazonSQS(sqs)
-                            .withInternalQueuePrefix(queueNamePrefix)
-                            .withQueueRetentionPeriodSeconds(idleQueueRetentionPeriod);
-        } else {
-            requesterBuilder =
-                    AmazonSQSRequesterClientBuilder.standard()
-                            .withAmazonSQS(sqs)
-                            .withInternalQueuePrefix(queueNamePrefix);
+            requesterBuilder = requesterBuilder.withIdleQueueRetentionPeriodSeconds(idleQueueRetentionPeriod);
         }
 
         client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
     }
 
-    private void createQueue(Long idleQueueRetentionPeriod) {
+    private void createQueueShouldSetRetentionPeriod(Long idleQueueRetentionPeriod) {
         setupClient(idleQueueRetentionPeriod);
         idleQueueRetentionPeriod = (idleQueueRetentionPeriod != null) ? idleQueueRetentionPeriod : 300L;
         queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
@@ -54,7 +54,7 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
     @Test
     public void createQueueWithUnsupportedIdleQueueRetentionPeriod() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            setupClient(500L);
+            setupClient(-10L);
         });
     }
 

--- a/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
+++ b/src/test/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClientIT.java
@@ -5,14 +5,12 @@ import static com.amazonaws.services.sqs.AmazonSQSVirtualQueuesClient.VIRTUAL_QU
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.QueueAttributeName;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.amazonaws.services.sqs.util.IntegrationTest;
@@ -23,75 +21,71 @@ public class AmazonSQSTemporaryQueuesClientIT extends IntegrationTest {
     private AmazonSQSTemporaryQueuesClient client;
     private String queueUrl;
     
-    @Before
-    public void setup() {
-        AmazonSQSRequesterClientBuilder requesterBuilder =
-                AmazonSQSRequesterClientBuilder.standard()
-                    .withAmazonSQS(sqs)
-                    .withInternalQueuePrefix(queueNamePrefix);
-        client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
-    }
-    
     @After
     public void teardown() {
         if (queueUrl != null) {
             client.deleteQueue(queueUrl);
         }
-        client.shutdown();
+        if (client != null) {
+            client.shutdown();
+        }
     }
     
     @Test
     public void createQueueAddsAttributes() {
-        queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
-        Map<String, String> attributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
-        String hostQueueUrl = attributes.get(VIRTUAL_QUEUE_HOST_QUEUE_ATTRIBUTE);
-        assertNotNull(hostQueueUrl);
-        Assert.assertEquals("300", attributes.get(IDLE_QUEUE_RETENTION_PERIOD));
-        
-        Map<String, String> hostQueueAttributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
-        Assert.assertEquals("300", hostQueueAttributes.get(AmazonSQSIdleQueueDeletingClient.IDLE_QUEUE_RETENTION_PERIOD));
+        createQueue(null);
     }
 
     @Test
     public void createQueueWithUnsupportedAttributes() {
-        try {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            setupClient(null);
             client.createQueue(new CreateQueueRequest()
                     .withQueueName(queueNamePrefix + "InvalidQueue")
                     .withAttributes(Collections.singletonMap(QueueAttributeName.FifoQueue.name(), "true")));
-            Assert.fail("Shouldn't be able to create a FIFO temporary queue");
-        } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Cannot create a temporary queue with the following attributes: FifoQueue", e.getMessage());
-        }
+        });
     }
 
     @Test
     public void createQueueConfigurableIdleQueueRetentionPeriod() {
-        AmazonSQSRequesterClientBuilder requesterBuilder =
-                AmazonSQSRequesterClientBuilder.standard()
-                        .withAmazonSQS(sqs)
-                        .withInternalQueuePrefix(queueNamePrefix)
-                        .withQueueRetentionPeriodSeconds(200);
-        client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
-
-        queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
-        Map<String, String> attributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
-        String hostQueueUrl = attributes.get(VIRTUAL_QUEUE_HOST_QUEUE_ATTRIBUTE);
-        assertNotNull(hostQueueUrl);
-        Assert.assertEquals("200", attributes.get(IDLE_QUEUE_RETENTION_PERIOD));
-
-        Map<String, String> hostQueueAttributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
-        Assert.assertEquals("200", hostQueueAttributes.get(AmazonSQSIdleQueueDeletingClient.IDLE_QUEUE_RETENTION_PERIOD));
+        createQueue(200L);
     }
 
     @Test
     public void createQueueWithUnsupportedIdleQueueRetentionPeriod() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            AmazonSQSRequesterClientBuilder requesterBuilder =
+            setupClient(500L);
+        });
+    }
+
+    private void setupClient(Long idleQueueRetentionPeriod) {
+        AmazonSQSRequesterClientBuilder requesterBuilder;
+        if (idleQueueRetentionPeriod != null) {
+            requesterBuilder =
                     AmazonSQSRequesterClientBuilder.standard()
                             .withAmazonSQS(sqs)
                             .withInternalQueuePrefix(queueNamePrefix)
-                            .withQueueRetentionPeriodSeconds(500);
-            client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
-        });
+                            .withQueueRetentionPeriodSeconds(idleQueueRetentionPeriod);
+        } else {
+            requesterBuilder =
+                    AmazonSQSRequesterClientBuilder.standard()
+                            .withAmazonSQS(sqs)
+                            .withInternalQueuePrefix(queueNamePrefix);
+        }
+
+        client = AmazonSQSTemporaryQueuesClient.make(requesterBuilder);
+    }
+
+    private void createQueue(Long idleQueueRetentionPeriod) {
+        setupClient(idleQueueRetentionPeriod);
+        idleQueueRetentionPeriod = (idleQueueRetentionPeriod != null) ? idleQueueRetentionPeriod : 300L;
+        queueUrl = client.createQueue(queueNamePrefix + "TestQueue").getQueueUrl();
+        Map<String, String> attributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
+        String hostQueueUrl = attributes.get(VIRTUAL_QUEUE_HOST_QUEUE_ATTRIBUTE);
+        assertNotNull(hostQueueUrl);
+        Assert.assertEquals(Long.toString(idleQueueRetentionPeriod), attributes.get(IDLE_QUEUE_RETENTION_PERIOD));
+
+        Map<String, String> hostQueueAttributes = client.getQueueAttributes(queueUrl, Collections.singletonList("All")).getAttributes();
+        Assert.assertEquals(Long.toString(idleQueueRetentionPeriod), hostQueueAttributes.get(AmazonSQSIdleQueueDeletingClient.IDLE_QUEUE_RETENTION_PERIOD));
     }
 }


### PR DESCRIPTION
Issue #38 

Description of changes: 
Allow configuration of IdleQueueRetentionPeriodSeconds on temporary queue client


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
