### PR TITLE
feat: heartbeat to virtual queues during ReceiveMessage as well

### DIFF
--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponderClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSResponderClientBuilder.java
@@ -65,7 +65,8 @@ public class AmazonSQSResponderClientBuilder {
     public AmazonSQSResponder build() {
         AmazonSQS sqs = customSQS.orElseGet(AmazonSQSClientBuilder::defaultClient);
         AmazonSQS deleter = new AmazonSQSIdleQueueDeletingClient(sqs, internalQueuePrefix, queueHeartbeatInterval);
-        AmazonSQS virtualQueuesClient = AmazonSQSVirtualQueuesClientBuilder.standard().withAmazonSQS(deleter).build();
+        AmazonSQS virtualQueuesClient = AmazonSQSVirtualQueuesClientBuilder.standard().withAmazonSQS(deleter)
+                .withHeartbeatIntervalSeconds(queueHeartbeatInterval).build();
         return new AmazonSQSResponderClient(virtualQueuesClient);
     }
 }

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
@@ -68,7 +68,10 @@ class AmazonSQSTemporaryQueuesClient extends AbstractAmazonSQSClientWrapper {
     public static AmazonSQSTemporaryQueuesClient make(AmazonSQSRequesterClientBuilder builder) {
         AmazonSQS sqs = builder.getAmazonSQS().orElseGet(AmazonSQSClientBuilder::defaultClient);
         AmazonSQSIdleQueueDeletingClient deleter = new AmazonSQSIdleQueueDeletingClient(sqs, builder.getInternalQueuePrefix(), builder.getQueueHeartbeatInterval());
-        AmazonSQS virtualizer = AmazonSQSVirtualQueuesClientBuilder.standard().withAmazonSQS(deleter).build();
+        AmazonSQS virtualizer = AmazonSQSVirtualQueuesClientBuilder.standard()
+                .withAmazonSQS(deleter)
+                .withHeartbeatIntervalSeconds(builder.getQueueHeartbeatInterval())
+                .build();
         AmazonSQSTemporaryQueuesClient temporaryQueuesClient = new AmazonSQSTemporaryQueuesClient(virtualizer, deleter, builder.getInternalQueuePrefix());
         AmazonSQSRequesterClient requester = new AmazonSQSRequesterClient(temporaryQueuesClient, builder.getInternalQueuePrefix(), builder.getQueueAttributes());
         AmazonSQSResponderClient responder = new AmazonSQSResponderClient(temporaryQueuesClient);

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
@@ -93,6 +93,9 @@ class AmazonSQSVirtualQueuesClient extends AbstractAmazonSQSClientWrapper {
     // This is currently only relevant for receives, since all operations on virtual queues
     // are handled locally and heartbeats are cheap. Only receives have any wait time and therefore
     // need to heartbeat *during* the operation.
+    // An alternative approach would be to remove the expiration scheduled task during the receive
+    // and restore it afterwards, but I prefer the hearbeating approach because it guards against
+    // threads dying or deadlocking.
     private final long heartbeatIntervalSeconds;
 
     private static final String VIRTUAL_QUEUE_NAME_ATTRIBUTE = "__AmazonSQSVirtualQueuesClient.QueueName";

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClient.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientBuilder.java
@@ -17,6 +17,8 @@ public class AmazonSQSVirtualQueuesClientBuilder {
 
     private int maxWaitTimeSeconds = 20;
 
+    private long heartbeatIntervalSeconds = AmazonSQSIdleQueueDeletingClient.HEARTBEAT_INTERVAL_SECONDS_DEFAULT;
+
     private AmazonSQSVirtualQueuesClientBuilder() {
     }
 
@@ -121,6 +123,19 @@ public class AmazonSQSVirtualQueuesClientBuilder {
         return this;
     }
 
+    public long getHeartbeatIntervalSeconds() {
+        return heartbeatIntervalSeconds;
+    }
+
+    public void setHeartbeatIntervalSeconds(long heartbeatIntervalSeconds) {
+        this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+    }
+
+    public AmazonSQSVirtualQueuesClientBuilder withHeartbeatIntervalSeconds(long heartbeatIntervalSeconds) {
+        setHeartbeatIntervalSeconds(heartbeatIntervalSeconds);
+        return this;
+    }
+
     /**
      * @return Create new instance of builder with all defaults set.
      */
@@ -130,6 +145,6 @@ public class AmazonSQSVirtualQueuesClientBuilder {
 
     public AmazonSQS build() {
         return new AmazonSQSVirtualQueuesClient(amazonSQS, messageHandler, orphanedMessageHandler,
-                                                hostQueuePollingThreads, maxWaitTimeSeconds);
+                                                hostQueuePollingThreads, maxWaitTimeSeconds, heartbeatIntervalSeconds);
     }
 }


### PR DESCRIPTION
Issue #47

Add local heartbeating to virtual queues during receive message calls, since they can be arbitrarily long for virtual queues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
