### PR TITLE
Make maxWaitTimeSeconds configurable on AmazonSQSRequesterClientBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 .idea
+*.iml
+

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSRequesterClientBuilder.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AmazonSQSRequesterClientBuilder {
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private Optional<AmazonSQS> customSQS = Optional.empty();
 
     private String internalQueuePrefix = "__RequesterClientQueues__";
@@ -18,6 +19,7 @@ public class AmazonSQSRequesterClientBuilder {
     private long queueHeartbeatInterval = AmazonSQSIdleQueueDeletingClient.HEARTBEAT_INTERVAL_SECONDS_DEFAULT;
     private TimeUnit idleQueueSweepingTimeUnit = TimeUnit.MINUTES;
     private long idleQueueRetentionPeriodSeconds = AmazonSQSTemporaryQueuesClientBuilder.IDLE_QUEUE_RETENTION_PERIOD_SECONDS_DEFAULT;
+    private int maxWaitTimeSeconds = 20;
     
     private AmazonSQSRequesterClientBuilder() {
     }
@@ -113,6 +115,19 @@ public class AmazonSQSRequesterClientBuilder {
 
     public AmazonSQSRequesterClientBuilder withQueueHeartbeatInterval(long heartbeatIntervalSeconds) {
         setQueueHeartbeatInterval(heartbeatIntervalSeconds);
+        return this;
+    }
+
+    public int getMaxWaitTimeSeconds() {
+        return maxWaitTimeSeconds;
+    }
+
+    public void setMaxWaitTimeSeconds(int maxWaitTimeSeconds) {
+        this.maxWaitTimeSeconds = maxWaitTimeSeconds;
+    }
+
+    public AmazonSQSRequesterClientBuilder withMaxWaitTimeSeconds(int maxWaitTimeSeconds) {
+        setMaxWaitTimeSeconds(maxWaitTimeSeconds);
         return this;
     }
 

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSTemporaryQueuesClient.java
@@ -80,6 +80,7 @@ class AmazonSQSTemporaryQueuesClient extends AbstractAmazonSQSClientWrapper {
         AmazonSQS virtualizer = AmazonSQSVirtualQueuesClientBuilder.standard()
                 .withAmazonSQS(deleter)
                 .withHeartbeatIntervalSeconds(builder.getQueueHeartbeatInterval())
+                .withMaxWaitTimeSeconds(builder.getMaxWaitTimeSeconds())
                 .build();
         AmazonSQSTemporaryQueuesClient temporaryQueuesClient = new AmazonSQSTemporaryQueuesClient(virtualizer, deleter, builder.getInternalQueuePrefix(), builder.getIdleQueueRetentionPeriodSeconds());
         AmazonSQSRequesterClient requester = new AmazonSQSRequesterClient(temporaryQueuesClient, builder.getInternalQueuePrefix(), builder.getQueueAttributes());

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientBuilder.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQSVirtualQueuesClientBuilder.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.sqs.model.Message;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class AmazonSQSVirtualQueuesClientBuilder {
 
     private AmazonSQS amazonSQS;
@@ -53,7 +54,6 @@ public class AmazonSQSVirtualQueuesClientBuilder {
      * Note that this callback will be invoked by internal threads managed by this client. It is <b>strongly recommended</b>
      * that this callback does not do significant processing or blocking operations, as this may delay the delivery
      * of other virtual queue messages!
-     * @return
      */
     public void setMessageHandler(Optional<BiConsumer<String, Message>> messageHandler) {
         this.messageHandler = messageHandler;
@@ -83,7 +83,6 @@ public class AmazonSQSVirtualQueuesClientBuilder {
      * Note that this callback will be invoked by internal threads managed by this client. It is <b>strongly recommended</b>
      * that this callback does not do significant processing or blocking operations, as this may delay the delivery
      * of other virtual queue messages!
-     * @return
      */
     public void setOrphanedMessageHandler(BiConsumer<String, Message> orphanedMessageHandler) {
         this.orphanedMessageHandler = orphanedMessageHandler;


### PR DESCRIPTION
Provide a way to shorten the default 20 second timeout waiting for a message.

Allows quick shutdown of client (e.g. in automated tests) when it is known that no more messages will arrive.